### PR TITLE
Add .vpc to support list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supports:
 .vmx
 .vdf
 .fgd
+.vpc
 ```
 
 ## Features
@@ -39,7 +40,8 @@ AnimatedTexture -> at
 I think this is useful for me🤔.
 
 # Release Notes
-
+## 0.0.6
+Add vpc to support list
 ## 0.0.4
 Add support for keyvalue without the quote mark
 Add .qc back to support list

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
                     ".kv",
                     ".res",
                     ".vmf",
-                    ".vmx"
+                    ".vmx",
+                    ".vpc"
                 ],
                 "configuration": "./language-configuration.json"
             },


### PR DESCRIPTION
.vpc (Valve project creator) is a keyvalue file format used to create solutions when developing for the source engine. This pull request adds the file extension .vpc to the support list and marks it as release 0.0.6